### PR TITLE
Add custom error pages and tighten Spring Boot error output

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,10 @@ endpoint.cityOfWinnipeg.query=closed_time IS NULL ORDER BY call_time desc LIMIT 
 # Logging
 ############
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=INFO
+############
+# Error handling
+############
+server.error.whitelabel.enabled=false
+server.error.include-stacktrace=never
+server.error.include-message=never
+

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Something went wrong | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">We ran into an issue</h1>
+                    <p class="lead mb-4">Sorry, the page could not be loaded right now.</p>
+                    <a href="/" class="btn btn-primary">Return to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page not found | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm border-warning">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">404 - Page not found</h1>
+                    <p class="lead mb-4">The URL you requested doesn't exist.</p>
+                    <a href="/" class="btn btn-primary">Back to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Server error | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm border-danger">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">500 - Server error</h1>
+                    <p class="lead mb-4">Something unexpected happened on our side. Please try again shortly.</p>
+                    <a href="/" class="btn btn-primary">Back to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide friendly, branded error pages for end users (generic, 404, and 500) instead of the default whitelabel page. 
- Avoid exposing stack traces or internal error messages in HTTP responses to reduce information leakage in production. 
- Surface a quick production-readiness note that synchronous data-sync work in `@PostConstruct` (in `AppController`) may make startup brittle and should be moved to a retryable background initializer.

### Description
- Added three Thymeleaf templates: `src/main/resources/templates/error.html`, `src/main/resources/templates/error/404.html`, and `src/main/resources/templates/error/500.html` with simple Bootstrap-based UIs. 
- Updated `src/main/resources/application.properties` to set `server.error.whitelabel.enabled=false`, `server.error.include-stacktrace=never`, and `server.error.include-message=never` to disable the default error page and suppress stack traces/messages.
- No other functional changes were made.

### Testing
- Ran `./mvnw test -q`, which failed because the Maven wrapper could not download its distribution due to network being unreachable. 
- Ran `mvn test -q`, which failed because dependency resolution from Maven Central returned HTTP 403 in this environment. 
- Attempted to load `http://127.0.0.1:8080/does-not-exist` with Playwright to capture the 404 page, but the application was not reachable so the check produced no screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e189afccc8323a70db02c25071376)