### PR TITLE
Fix incident map plotting regressions and add ward fallback locations

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,10 @@ endpoint.cityOfWinnipeg.query=closed_time IS NULL ORDER BY call_time desc LIMIT 
 # Logging
 ############
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=INFO
+############
+# Error handling
+############
+server.error.whitelabel.enabled=false
+server.error.include-stacktrace=never
+server.error.include-message=never
+

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Something went wrong | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">We ran into an issue</h1>
+                    <p class="lead mb-4">Sorry, the page could not be loaded right now.</p>
+                    <a href="/" class="btn btn-primary">Return to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page not found | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm border-warning">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">404 - Page not found</h1>
+                    <p class="lead mb-4">The URL you requested doesn't exist.</p>
+                    <a href="/" class="btn btn-primary">Back to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/error/500.html
+++ b/src/main/resources/templates/error/500.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Server error | WFPS Incidents</title>
+    <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
+</head>
+<body class="bg-light">
+<div class="container py-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm border-danger">
+                <div class="card-body p-4 text-center">
+                    <h1 class="display-6 mb-3">500 - Server error</h1>
+                    <p class="lead mb-4">Something unexpected happened on our side. Please try again shortly.</p>
+                    <a href="/" class="btn btn-primary">Back to incident map</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://use.fontawesome.com/releases/v6.2.0/js/all.js"></script>
@@ -47,9 +46,6 @@
         </div>
     </div>
 </div>
-</body>
-
-</html>
 
 <script th:inline="javascript">
     const incidents = /*[[${incidents}]]*/ [];
@@ -61,6 +57,25 @@
     }).addTo(map);
 
     const neighbourhoodCoordinatesCache = {};
+    const geocodeFailures = new Set();
+    const wardCentres = {
+        'Assiniboia': [49.8573, -97.2835],
+        'Charleswood - Tuxedo - Westwood': [49.8569, -97.2525],
+        'Daniel McIntyre': [49.9022, -97.1687],
+        'Elmwood - East Kildonan': [49.9307, -97.0708],
+        'Fort Garry': [49.8232, -97.1520],
+        'Mynarski': [49.9290, -97.1483],
+        'North Kildonan': [49.9545, -97.0671],
+        'Old Kildonan': [49.9760, -97.1128],
+        'Point Douglas': [49.9077, -97.1150],
+        'River Heights - Fort Garry': [49.8584, -97.1748],
+        'St. Boniface': [49.8864, -97.1080],
+        'St. James': [49.8857, -97.2147],
+        'St. Norbert - Seine River': [49.7707, -97.1543],
+        'St. Vital': [49.8344, -97.1118],
+        'Transcona': [49.8966, -97.0010],
+        'Waverley West': [49.7927, -97.1854]
+    };
 
     function escapeHtml(value) {
         return String(value ?? '').replace(/[&<>'"]/g, (char) => ({
@@ -72,6 +87,22 @@
         }[char]));
     }
 
+    function jitterCoordinates(baseCoordinates, seedText) {
+        if (!baseCoordinates) {
+            return null;
+        }
+
+        let hash = 0;
+        for (const character of String(seedText ?? '')) {
+            hash = ((hash << 5) - hash) + character.charCodeAt(0);
+            hash |= 0;
+        }
+
+        const latJitter = ((hash & 15) - 8) * 0.0007;
+        const lngJitter = (((hash >> 4) & 15) - 8) * 0.0007;
+        return [baseCoordinates[0] + latJitter, baseCoordinates[1] + lngJitter];
+    }
+
     async function geocodeNeighbourhood(neighbourhoodName) {
         if (!neighbourhoodName) {
             return null;
@@ -79,27 +110,51 @@
         if (neighbourhoodCoordinatesCache[neighbourhoodName]) {
             return neighbourhoodCoordinatesCache[neighbourhoodName];
         }
+        if (geocodeFailures.has(neighbourhoodName)) {
+            return null;
+        }
 
         const query = encodeURIComponent(`${neighbourhoodName}, Winnipeg, Manitoba, Canada`);
-        const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${query}`);
-        if (!response.ok) {
+        try {
+            const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${query}`);
+            if (!response.ok) {
+                geocodeFailures.add(neighbourhoodName);
+                return null;
+            }
+
+            const results = await response.json();
+            if (!results.length) {
+                geocodeFailures.add(neighbourhoodName);
+                return null;
+            }
+
+            const coordinates = [parseFloat(results[0].lat), parseFloat(results[0].lon)];
+            neighbourhoodCoordinatesCache[neighbourhoodName] = coordinates;
+            return coordinates;
+        } catch (error) {
+            geocodeFailures.add(neighbourhoodName);
             return null;
         }
+    }
 
-        const results = await response.json();
-        if (!results.length) {
-            return null;
+    async function getIncidentCoordinates(incident) {
+        const neighbourhood = incident.NEIGHBOURHOOD;
+        const geocodedCoordinates = await geocodeNeighbourhood(neighbourhood);
+        if (geocodedCoordinates) {
+            return jitterCoordinates(geocodedCoordinates, incident.INCIDENT_NUMBER);
         }
 
-        const coordinates = [parseFloat(results[0].lat), parseFloat(results[0].lon)];
-        neighbourhoodCoordinatesCache[neighbourhoodName] = coordinates;
-        return coordinates;
+        const wardCoordinates = wardCentres[incident.WARD];
+        if (wardCoordinates) {
+            return jitterCoordinates(wardCoordinates, incident.INCIDENT_NUMBER);
+        }
+
+        return null;
     }
 
     async function plotIncidents() {
         for (const incident of incidents) {
-            const neighbourhood = incident.NEIGHBOURHOOD;
-            const coordinates = await geocodeNeighbourhood(neighbourhood);
+            const coordinates = await getIncidentCoordinates(incident);
             if (!coordinates) {
                 continue;
             }
@@ -122,3 +177,5 @@
 
     plotIncidents();
 </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Restore incident plotting after a previous template edit moved/removed script content and caused markers to not render in some environments. 
- Make plotting resilient when neighbourhood geocoding fails so incidents still appear on the map. 
- Provide friendly, non-leaking error pages and tighten server error output for production safety.

### Description
- Moved the map/plotting script into the page `body` so it executes in a valid location and fixed related markup in `src/main/resources/templates/index.html`.
- Added a robust coordinate resolution flow with `getIncidentCoordinates()`, including cached failed geocoding (`geocodeFailures`), ward-centroid fallbacks (`wardCentres`), and deterministic `jitterCoordinates()` to reduce marker overlap.
- Improved neighbourhood geocoding to be error-tolerant and cache results in `neighbourhoodCoordinatesCache` to avoid repeated failed lookups.
- Added friendly error templates (`src/main/resources/templates/error.html`, `.../error/404.html`, `.../error/500.html`) and tightened Spring Boot error settings in `src/main/resources/application.properties` (`server.error.whitelabel.enabled=false`, `server.error.include-stacktrace=never`, `server.error.include-message=never`).

### Testing
- Attempted `./mvnw test -q`, which failed in this environment because the Maven wrapper could not download its distribution (network unavailable). 
- Attempted `mvn test -q`, which failed due to dependency resolution being blocked/forbidden by the environment (HTTP 403 from Maven Central). 
- Ran the Playwright page check that navigates to `http://127.0.0.1:8080/`, which failed with `net::ERR_EMPTY_RESPONSE` because the application was not reachable on port 8080 in this runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e189afccc8323a70db02c25071376)