### PR TITLE
Make incidents view mobile-friendly and add Fire/Medical categorization

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -19,6 +19,91 @@ body {
     padding: 0;
 }
 
+.page-title {
+    margin: 0.75rem 0;
+    text-align: center;
+}
+
+.map-panel {
+    width: 100%;
+    height: 55vh;
+    min-height: 20rem;
+    border-radius: 0.5rem;
+}
+
+.incident-table-wrapper {
+    max-height: 88vh;
+    background-color: #fff;
+    border-radius: 0.5rem;
+    overflow: auto;
+}
+
+.incident-table {
+    margin-bottom: 0;
+}
+
+.incident-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: #f8f9fa;
+}
+
+.incident-row-fire {
+    border-left: 4px solid #dc3545;
+}
+
+.incident-row-medical {
+    border-left: 4px solid #0d6efd;
+}
+
+.incident-row-other {
+    border-left: 4px solid #6c757d;
+}
+
+.incident-badge {
+    font-weight: 600;
+}
+
+.incident-badge-fire {
+    background-color: #dc3545;
+}
+
+.incident-badge-medical {
+    background-color: #0d6efd;
+}
+
+.incident-badge-other {
+    background-color: #6c757d;
+}
+
+.incident-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.incident-chip {
+    border-radius: 1rem;
+    color: #fff;
+    display: inline-block;
+    font-size: 0.85rem;
+    padding: 0.25rem 0.65rem;
+}
+
+.incident-chip-fire {
+    background-color: #dc3545;
+}
+
+.incident-chip-medical {
+    background-color: #0d6efd;
+}
+
+.incident-chip-other {
+    background-color: #6c757d;
+}
+
 /*
  * Always set the map height explicitly to define the size of the div element
  * that contains the map.
@@ -26,6 +111,59 @@ body {
 #map {
     height: 100%;
     width: 100%;
+}
+
+@media (min-width: 1200px) {
+    .map-panel {
+        height: 88vh;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .incident-table-wrapper {
+        max-height: none;
+        overflow: visible;
+    }
+
+    .incident-table thead {
+        display: none;
+    }
+
+    .incident-table,
+    .incident-table tbody,
+    .incident-table tr,
+    .incident-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .incident-table tr {
+        border: 1px solid #dee2e6;
+        border-radius: 0.5rem;
+        margin-bottom: 0.75rem;
+        padding: 0.25rem 0.5rem;
+    }
+
+    .incident-table td {
+        border: 0;
+        border-bottom: 1px solid #f1f3f5;
+        display: flex;
+        gap: 0.5rem;
+        justify-content: space-between;
+        padding: 0.45rem 0;
+        text-align: right;
+    }
+
+    .incident-table td:last-child {
+        border-bottom: 0;
+    }
+
+    .incident-table td::before {
+        color: #495057;
+        content: attr(data-label);
+        font-weight: 600;
+        text-align: left;
+    }
 }
 
 /*

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,6 +7,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>WFPS Incidents</title>
 
     <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
@@ -16,33 +17,51 @@
 <body>
 <div class="container-fluid">
 
-    <div class="row">
-        <div class="col-md-6">
-            <h1 style="text-align:center">WFPS Active Incident Map:</h1>
-            <div id="map" style="width: 100%; height: 100vh"></div>
+    <h1 class="page-title">WFPS Active Incident Map</h1>
+    <div class="row g-3 align-items-start">
+        <div class="col-12 col-xl-7">
+            <div id="map" class="map-panel"></div>
 
         </div>
-        <div class="col-md-6">
-            <table class="table table-hover">
-                <tr>
-                    <th>Incident Type</th>
-                    <th>Motor Vehicle Incident?</th>
-                    <th>Neighbourhood</th>
-                    <th>Call Time</th>
-                    <th>Units Dispatched</th>
-                    <th>Ward</th>
-                    <th>Incident Number</th>
-                </tr>
-                <tr th:each="data: ${incidents}">
-                    <td><span th:text="${data.INCIDENT_TYPE}"></span></td>
-                    <td><span th:text="${data.IS_MOTOR}"></span></td>
-                    <td><span th:text="${data.NEIGHBOURHOOD}"></span></td>
-                    <td><span th:text="${data.CALL_TIME}"></span></td>
-                    <td><span th:text="${data.UNITS}"></span></td>
-                    <td><span th:text="${data.WARD}"></span></td>
-                    <td><span th:text="${data.INCIDENT_NUMBER}"></span></td>
-                </tr>
-            </table>
+        <div class="col-12 col-xl-5">
+            <div class="incident-legend">
+                <span class="incident-chip incident-chip-fire">Fire Rescue</span>
+                <span class="incident-chip incident-chip-medical">Medical Response</span>
+                <span class="incident-chip incident-chip-other">Other Calls</span>
+            </div>
+            <div class="table-responsive incident-table-wrapper">
+                <table class="table table-hover incident-table">
+                    <thead>
+                    <tr>
+                        <th>Incident Type</th>
+                        <th>Category</th>
+                        <th>Motor Vehicle Incident?</th>
+                        <th>Neighbourhood</th>
+                        <th>Call Time</th>
+                        <th>Units Dispatched</th>
+                        <th>Ward</th>
+                        <th>Incident Number</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="data: ${incidents}"
+                        th:with="incidentType=${data.INCIDENT_TYPE != null ? data.INCIDENT_TYPE.toLowerCase() : ''}, incidentCategory=${#strings.startsWith(incidentType, 'fire rescue') ? 'fire' : (#strings.contains(incidentType, 'medical response') ? 'medical' : 'other')}"
+                        th:classappend="|incident-row incident-row-${incidentCategory}|">
+                        <td data-label="Incident Type"><span th:text="${data.INCIDENT_TYPE}"></span></td>
+                        <td data-label="Category"><span class="badge"
+                                                      th:classappend="| incident-badge incident-badge-${incidentCategory}|"
+                                                      th:text="${incidentCategory == 'fire' ? 'Fire Rescue' : (incidentCategory == 'medical' ? 'Medical Response' : 'Other')}"
+                        ></span></td>
+                        <td data-label="Motor Vehicle Incident?"><span th:text="${data.IS_MOTOR}"></span></td>
+                        <td data-label="Neighbourhood"><span th:text="${data.NEIGHBOURHOOD}"></span></td>
+                        <td data-label="Call Time"><span th:text="${data.CALL_TIME}"></span></td>
+                        <td data-label="Units Dispatched"><span th:text="${data.UNITS}"></span></td>
+                        <td data-label="Ward"><span th:text="${data.WARD}"></span></td>
+                        <td data-label="Incident Number"><span th:text="${data.INCIDENT_NUMBER}"></span></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>
@@ -85,6 +104,28 @@
             "'": '&#39;',
             '"': '&quot;'
         }[char]));
+    }
+
+    function getIncidentCategory(incidentType) {
+        const normalizedType = String(incidentType ?? '').toLowerCase();
+        if (normalizedType.startsWith('fire rescue')) {
+            return 'fire';
+        }
+        if (normalizedType.includes('medical response')) {
+            return 'medical';
+        }
+        return 'other';
+    }
+
+    function getCategoryColor(incidentType) {
+        switch (getIncidentCategory(incidentType)) {
+            case 'fire':
+                return '#dc3545';
+            case 'medical':
+                return '#0d6efd';
+            default:
+                return '#6c757d';
+        }
     }
 
     function jitterCoordinates(baseCoordinates, seedText) {
@@ -161,15 +202,18 @@
 
             const popup = `
                 <strong>${escapeHtml(incident.INCIDENT_TYPE)}</strong><br/>
+                Category: ${escapeHtml(getIncidentCategory(incident.INCIDENT_TYPE))}<br/>
                 Neighbourhood: ${escapeHtml(incident.NEIGHBOURHOOD)}<br/>
                 Units: ${escapeHtml(incident.UNITS ?? 'No Response')}<br/>
                 Call Time: ${escapeHtml(incident.CALL_TIME)}
             `;
 
+            const markerColor = getCategoryColor(incident.INCIDENT_TYPE);
+
             L.circleMarker(coordinates, {
                 radius: 7,
-                color: '#dc3545',
-                fillColor: '#dc3545',
+                color: markerColor,
+                fillColor: markerColor,
                 fillOpacity: 0.6
             }).addTo(map).bindPopup(popup);
         }


### PR DESCRIPTION
### Motivation
- Improve usability on small screens by making the map + incidents list stack neatly on phones while preserving a split layout on large screens. 
- Make it easy to visually differentiate Fire Rescue calls from Medical Response and other calls, including common `Fire Rescue - ...` patterns.

### Description
- Added a viewport meta tag and reworked the page layout to use responsive Bootstrap columns and a dedicated `.map-panel` so the map and list behave correctly across screen sizes in `src/main/resources/templates/index.html`.
- Replaced the previous table with a responsive table-wrapper and mobile-friendly card-style rows that use `data-label` for stacked cell labels and added a small legend and badges for categories in `index.html` and `src/main/resources/static/css/main.css`.
- Implemented simple category detection in client-side JavaScript that classifies calls starting with `fire rescue` as `fire`, calls containing `medical response` as `medical`, and otherwise `other`, and applied category-specific marker colors and popup text in `index.html`.
- Added CSS for sticky headers on wide screens, mobile stacked rows, category row accents, badges, and responsive map height tuning in `src/main/resources/static/css/main.css`.

### Testing
- Ran `./mvnw test` which failed in this environment due to network/DNS issues when the Maven wrapper tried to download dependencies (`java.net.SocketException: Network is unreachable`).
- Executed an automated Playwright rendering script that opened the page at mobile viewport and produced a screenshot `artifacts/mobile-view-styled.png`, which validated the responsive layout and styling (script completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f14b299c883238bfda8722e0b38bd)