### PR TITLE
Responsive incident table, legend, and category-colored map markers

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -19,6 +19,123 @@ body {
     padding: 0;
 }
 
+.page-title {
+    margin: 0.75rem 0;
+    text-align: center;
+}
+
+.map-panel {
+    width: 100%;
+    height: 70vh;
+    min-height: 24rem;
+    border-radius: 0.5rem;
+}
+
+.incident-table-panel {
+    margin-top: 1rem;
+}
+
+.incident-table-toggle {
+    align-items: baseline;
+    background-color: #f8f9fa;
+    border: 1px solid #dee2e6;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    font-weight: 600;
+    list-style: none;
+    padding: 0.75rem 1rem;
+}
+
+.incident-table-toggle::-webkit-details-marker {
+    display: none;
+}
+
+.incident-table-toggle-hint {
+    color: #6c757d;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.incident-table-panel:not([open]) .incident-table-toggle-hint::after {
+    content: " (collapsed)";
+}
+
+.incident-table-wrapper {
+    max-height: 55vh;
+    background-color: #fff;
+    border-radius: 0.5rem;
+    margin-top: 0.75rem;
+    overflow: auto;
+}
+
+.incident-table {
+    margin-bottom: 0;
+}
+
+.incident-table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: #f8f9fa;
+}
+
+.incident-row-fire {
+    border-left: 4px solid #dc3545;
+}
+
+.incident-row-medical {
+    border-left: 4px solid #0d6efd;
+}
+
+.incident-row-other {
+    border-left: 4px solid #6c757d;
+}
+
+.incident-badge {
+    font-weight: 600;
+}
+
+.incident-badge-fire {
+    background-color: #dc3545;
+}
+
+.incident-badge-medical {
+    background-color: #0d6efd;
+}
+
+.incident-badge-other {
+    background-color: #6c757d;
+}
+
+.incident-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.incident-chip {
+    border-radius: 1rem;
+    color: #fff;
+    display: inline-block;
+    font-size: 0.85rem;
+    padding: 0.25rem 0.65rem;
+}
+
+.incident-chip-fire {
+    background-color: #dc3545;
+}
+
+.incident-chip-medical {
+    background-color: #0d6efd;
+}
+
+.incident-chip-other {
+    background-color: #6c757d;
+}
+
 /*
  * Always set the map height explicitly to define the size of the div element
  * that contains the map.
@@ -26,6 +143,70 @@ body {
 #map {
     height: 100%;
     width: 100%;
+}
+
+@media (min-width: 1200px) {
+    .map-panel {
+        height: 72vh;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .map-panel {
+        height: 50vh;
+        min-height: 18rem;
+    }
+
+    .incident-table-toggle {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.2rem;
+    }
+
+    .incident-table-wrapper {
+        max-height: none;
+        overflow: visible;
+    }
+
+    .incident-table thead {
+        display: none;
+    }
+
+    .incident-table,
+    .incident-table tbody,
+    .incident-table tr,
+    .incident-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .incident-table tr {
+        border: 1px solid #dee2e6;
+        border-radius: 0.5rem;
+        margin-bottom: 0.75rem;
+        padding: 0.25rem 0.5rem;
+    }
+
+    .incident-table td {
+        border: 0;
+        border-bottom: 1px solid #f1f3f5;
+        display: flex;
+        gap: 0.5rem;
+        justify-content: space-between;
+        padding: 0.45rem 0;
+        text-align: right;
+    }
+
+    .incident-table td:last-child {
+        border-bottom: 0;
+    }
+
+    .incident-table td::before {
+        color: #495057;
+        content: attr(data-label);
+        font-weight: 600;
+        text-align: left;
+    }
 }
 
 /*

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,6 +7,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>WFPS Incidents</title>
 
     <link rel="stylesheet" href="https://bootswatch.com/5/minty/bootstrap.css" />
@@ -16,16 +17,27 @@
 <body>
 <div class="container-fluid">
 
-    <div class="row">
-        <div class="col-md-6">
-            <h1 style="text-align:center">WFPS Active Incident Map:</h1>
-            <div id="map" style="width: 100%; height: 100vh"></div>
+    <h1 class="page-title">WFPS Active Incident Map</h1>
+    <div id="map" class="map-panel"></div>
 
+    <details class="incident-table-panel" open>
+        <summary class="incident-table-toggle">
+            <span>Active Incident Table</span>
+            <span class="incident-table-toggle-hint">Tap or click to collapse</span>
+        </summary>
+
+        <div class="incident-legend">
+            <span class="incident-chip incident-chip-fire">Fire Rescue</span>
+            <span class="incident-chip incident-chip-medical">Medical Response</span>
+            <span class="incident-chip incident-chip-other">Other Calls</span>
         </div>
-        <div class="col-md-6">
-            <table class="table table-hover">
+
+        <div class="table-responsive incident-table-wrapper">
+            <table class="table table-hover incident-table">
+                <thead>
                 <tr>
                     <th>Incident Type</th>
+                    <th>Category</th>
                     <th>Motor Vehicle Incident?</th>
                     <th>Neighbourhood</th>
                     <th>Call Time</th>
@@ -33,18 +45,27 @@
                     <th>Ward</th>
                     <th>Incident Number</th>
                 </tr>
-                <tr th:each="data: ${incidents}">
-                    <td><span th:text="${data.INCIDENT_TYPE}"></span></td>
-                    <td><span th:text="${data.IS_MOTOR}"></span></td>
-                    <td><span th:text="${data.NEIGHBOURHOOD}"></span></td>
-                    <td><span th:text="${data.CALL_TIME}"></span></td>
-                    <td><span th:text="${data.UNITS}"></span></td>
-                    <td><span th:text="${data.WARD}"></span></td>
-                    <td><span th:text="${data.INCIDENT_NUMBER}"></span></td>
+                </thead>
+                <tbody>
+                <tr th:each="data: ${incidents}"
+                    th:with="incidentType=${data.INCIDENT_TYPE != null ? data.INCIDENT_TYPE.toLowerCase() : ''}, incidentCategory=${#strings.startsWith(incidentType, 'fire rescue') ? 'fire' : (#strings.contains(incidentType, 'medical response') ? 'medical' : 'other')}"
+                    th:classappend="|incident-row incident-row-${incidentCategory}|">
+                    <td data-label="Incident Type"><span th:text="${data.INCIDENT_TYPE}"></span></td>
+                    <td data-label="Category"><span class="badge"
+                                                  th:classappend="| incident-badge incident-badge-${incidentCategory}|"
+                                                  th:text="${incidentCategory == 'fire' ? 'Fire Rescue' : (incidentCategory == 'medical' ? 'Medical Response' : 'Other')}"
+                    ></span></td>
+                    <td data-label="Motor Vehicle Incident?"><span th:text="${data.IS_MOTOR}"></span></td>
+                    <td data-label="Neighbourhood"><span th:text="${data.NEIGHBOURHOOD}"></span></td>
+                    <td data-label="Call Time"><span th:text="${data.CALL_TIME}"></span></td>
+                    <td data-label="Units Dispatched"><span th:text="${data.UNITS}"></span></td>
+                    <td data-label="Ward"><span th:text="${data.WARD}"></span></td>
+                    <td data-label="Incident Number"><span th:text="${data.INCIDENT_NUMBER}"></span></td>
                 </tr>
+                </tbody>
             </table>
         </div>
-    </div>
+    </details>
 </div>
 
 <script th:inline="javascript">
@@ -85,6 +106,28 @@
             "'": '&#39;',
             '"': '&quot;'
         }[char]));
+    }
+
+    function getIncidentCategory(incidentType) {
+        const normalizedType = String(incidentType ?? '').toLowerCase();
+        if (normalizedType.startsWith('fire rescue')) {
+            return 'fire';
+        }
+        if (normalizedType.includes('medical response')) {
+            return 'medical';
+        }
+        return 'other';
+    }
+
+    function getCategoryColor(incidentType) {
+        switch (getIncidentCategory(incidentType)) {
+            case 'fire':
+                return '#dc3545';
+            case 'medical':
+                return '#0d6efd';
+            default:
+                return '#6c757d';
+        }
     }
 
     function jitterCoordinates(baseCoordinates, seedText) {
@@ -161,15 +204,18 @@
 
             const popup = `
                 <strong>${escapeHtml(incident.INCIDENT_TYPE)}</strong><br/>
+                Category: ${escapeHtml(getIncidentCategory(incident.INCIDENT_TYPE))}<br/>
                 Neighbourhood: ${escapeHtml(incident.NEIGHBOURHOOD)}<br/>
                 Units: ${escapeHtml(incident.UNITS ?? 'No Response')}<br/>
                 Call Time: ${escapeHtml(incident.CALL_TIME)}
             `;
 
+            const markerColor = getCategoryColor(incident.INCIDENT_TYPE);
+
             L.circleMarker(coordinates, {
                 radius: 7,
-                color: '#dc3545',
-                fillColor: '#dc3545',
+                color: markerColor,
+                fillColor: markerColor,
                 fillOpacity: 0.6
             }).addTo(map).bindPopup(popup);
         }


### PR DESCRIPTION
### Motivation
- Improve the incident UI so the map and incident list are usable on mobile and desktop by providing responsive layout and collapsible table behavior. 
- Surface incident categories (Fire / Medical / Other) in the table and map so users can quickly scan severity/type. 
- Make markers visually consistent with the table by coloring markers and badges by category and add a viewport meta tag for better mobile rendering.

### Description
- Revamped `src/main/resources/static/css/main.css` to introduce responsive layout classes such as `.map-panel`, `.page-title`, `.incident-table-wrapper`, legend/chip styles, and mobile-specific table styles. 
- Replaced the old two-column layout in `src/main/resources/templates/index.html` with a single map panel and a collapsible `<details>`-based incident table that includes an incident legend and responsive table markup. 
- Updated the table rows to compute `incidentCategory` with Thymeleaf (`th:with`) and apply row/badge classes (`incident-row-*`, `incident-badge-*`) to show category-specific styling. 
- Added client-side helpers in the inline script: `getIncidentCategory` and `getCategoryColor`, included category in marker popup, and used the category color for `L.circleMarker` markers. 
- Kept and reused existing helper logic such as `jitterCoordinates`, `geocodeNeighbourhood`, and `getIncidentCoordinates` while wiring category-aware popups and marker colors.

### Testing
- No automated tests were added or executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f14b299c883238bfda8722e0b38bd)