### PR TITLE
Fix map/table responsive layout and remove duplicate legend

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -19,6 +19,11 @@ body {
     padding: 0;
 }
 
+.app-shell {
+    min-height: 100vh;
+    padding-bottom: 1rem;
+}
+
 .page-title {
     margin: 0.75rem 0;
     text-align: center;
@@ -26,13 +31,30 @@ body {
 
 .map-panel {
     width: 100%;
-    height: 55vh;
-    min-height: 20rem;
+    height: min(72vh, 52rem);
+    min-height: 24rem;
     border-radius: 0.5rem;
 }
 
+.incident-table-panel {
+    margin-top: 0.5rem;
+}
+
+.incident-table-toggle {
+    color: #6c757d;
+    cursor: pointer;
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.incident-table-toggle-hint {
+    color: #6c757d;
+}
+
 .incident-table-wrapper {
-    max-height: 88vh;
+    max-height: clamp(16rem, 34vh, 30rem);
     background-color: #fff;
     border-radius: 0.5rem;
     overflow: auto;
@@ -109,13 +131,16 @@ body {
  * that contains the map.
  */
 #map {
-    height: 100%;
     width: 100%;
 }
 
 @media (min-width: 1200px) {
     .map-panel {
-        height: 88vh;
+        height: min(74vh, 56rem);
+    }
+
+    .incident-table-wrapper {
+        max-height: clamp(18rem, 28vh, 24rem);
     }
 }
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -15,12 +15,10 @@
 </head>
 
 <body>
-<div class="container-fluid">
-
+<div class="container-fluid app-shell">
     <h1 class="page-title">WFPS Active Incident Map</h1>
-    <div class="row g-3 align-items-start">
-        <div class="col-12 col-xl-7">
-            <div id="map" class="map-panel"></div>
+
+    <div id="map" class="map-panel"></div>
 
     <details class="incident-table-panel" open>
         <summary class="incident-table-toggle">
@@ -33,45 +31,39 @@
             <span class="incident-chip incident-chip-medical">Medical Response</span>
             <span class="incident-chip incident-chip-other">Other Calls</span>
         </div>
-        <div class="col-12 col-xl-5">
-            <div class="incident-legend">
-                <span class="incident-chip incident-chip-fire">Fire Rescue</span>
-                <span class="incident-chip incident-chip-medical">Medical Response</span>
-                <span class="incident-chip incident-chip-other">Other Calls</span>
-            </div>
-            <div class="table-responsive incident-table-wrapper">
-                <table class="table table-hover incident-table">
-                    <thead>
-                    <tr>
-                        <th>Incident Type</th>
-                        <th>Category</th>
-                        <th>Motor Vehicle Incident?</th>
-                        <th>Neighbourhood</th>
-                        <th>Call Time</th>
-                        <th>Units Dispatched</th>
-                        <th>Ward</th>
-                        <th>Incident Number</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="data: ${incidents}"
-                        th:with="incidentType=${data.INCIDENT_TYPE != null ? data.INCIDENT_TYPE.toLowerCase() : ''}, incidentCategory=${#strings.startsWith(incidentType, 'fire rescue') ? 'fire' : (#strings.contains(incidentType, 'medical response') ? 'medical' : 'other')}"
-                        th:classappend="|incident-row incident-row-${incidentCategory}|">
-                        <td data-label="Incident Type"><span th:text="${data.INCIDENT_TYPE}"></span></td>
-                        <td data-label="Category"><span class="badge"
-                                                      th:classappend="| incident-badge incident-badge-${incidentCategory}|"
-                                                      th:text="${incidentCategory == 'fire' ? 'Fire Rescue' : (incidentCategory == 'medical' ? 'Medical Response' : 'Other')}"
-                        ></span></td>
-                        <td data-label="Motor Vehicle Incident?"><span th:text="${data.IS_MOTOR}"></span></td>
-                        <td data-label="Neighbourhood"><span th:text="${data.NEIGHBOURHOOD}"></span></td>
-                        <td data-label="Call Time"><span th:text="${data.CALL_TIME}"></span></td>
-                        <td data-label="Units Dispatched"><span th:text="${data.UNITS}"></span></td>
-                        <td data-label="Ward"><span th:text="${data.WARD}"></span></td>
-                        <td data-label="Incident Number"><span th:text="${data.INCIDENT_NUMBER}"></span></td>
-                    </tr>
-                    </tbody>
-                </table>
-            </div>
+
+        <div class="table-responsive incident-table-wrapper">
+            <table class="table table-hover incident-table">
+                <thead>
+                <tr>
+                    <th>Incident Type</th>
+                    <th>Category</th>
+                    <th>Motor Vehicle Incident?</th>
+                    <th>Neighbourhood</th>
+                    <th>Call Time</th>
+                    <th>Units Dispatched</th>
+                    <th>Ward</th>
+                    <th>Incident Number</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="data: ${incidents}"
+                    th:with="incidentType=${data.INCIDENT_TYPE != null ? data.INCIDENT_TYPE.toLowerCase() : ''}, incidentCategory=${#strings.startsWith(incidentType, 'fire rescue') ? 'fire' : (#strings.contains(incidentType, 'medical response') ? 'medical' : 'other')}"
+                    th:classappend="|incident-row incident-row-${incidentCategory}|">
+                    <td data-label="Incident Type"><span th:text="${data.INCIDENT_TYPE}"></span></td>
+                    <td data-label="Category"><span class="badge"
+                                                  th:classappend="| incident-badge incident-badge-${incidentCategory}|"
+                                                  th:text="${incidentCategory == 'fire' ? 'Fire Rescue' : (incidentCategory == 'medical' ? 'Medical Response' : 'Other')}"
+                    ></span></td>
+                    <td data-label="Motor Vehicle Incident?"><span th:text="${data.IS_MOTOR}"></span></td>
+                    <td data-label="Neighbourhood"><span th:text="${data.NEIGHBOURHOOD}"></span></td>
+                    <td data-label="Call Time"><span th:text="${data.CALL_TIME}"></span></td>
+                    <td data-label="Units Dispatched"><span th:text="${data.UNITS}"></span></td>
+                    <td data-label="Ward"><span th:text="${data.WARD}"></span></td>
+                    <td data-label="Incident Number"><span th:text="${data.INCIDENT_NUMBER}"></span></td>
+                </tr>
+                </tbody>
+            </table>
         </div>
     </details>
 </div>
@@ -228,6 +220,15 @@
             }).addTo(map).bindPopup(popup);
         }
     }
+
+    const incidentPanel = document.querySelector('.incident-table-panel');
+    if (incidentPanel) {
+        incidentPanel.addEventListener('toggle', () => {
+            window.requestAnimationFrame(() => map.invalidateSize());
+        });
+    }
+
+    window.addEventListener('resize', () => map.invalidateSize());
 
     plotIncidents();
 </script>


### PR DESCRIPTION
### Motivation
- The map no longer filled the available page area and could be constrained by nested grid markup, reducing usability.  
- The incident table needed to be reactive to viewport height so it remains readable without overflowing the page.  
- Two copies of the legend were rendered; a single legend is sufficient and avoids duplication.

### Description
- Reworked page structure in `index.html` so the map is a full-width top section and the collapsible incident table sits beneath it in a single panel, removing the nested Bootstrap grid that limited map width.  
- Removed the duplicate legend so only one set of chips (Fire / Medical / Other) is shown above the table.  
- Updated `src/main/resources/static/css/main.css` to add `.app-shell`, tune `.map-panel` sizing with viewport-based limits, make the incident table wrapper height adaptive via `clamp()`, and add styles for the collapsible table summary.  
- Added JavaScript handlers to call `map.invalidateSize()` on the table panel `toggle` event and on window `resize` so Leaflet reflows after layout changes.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.  
- Ran `mvn test -q` which failed in this environment because app startup attempts to reach the external Winnipeg open-data endpoint and the environment returns `java.net.SocketException: Network is unreachable`.  
- Ran `mvn spring-boot:run -DskipTests` which also failed during startup for the same outbound network dependency.  
- Attempted a Playwright screenshot of `http://127.0.0.1:8080`, but the app server could not be started here (resulting in `ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f184dedc483238d144dffc1d4cfe3)