### PR TITLE
Make incidents table schema self-healing on startup

### DIFF
--- a/src/main/java/ca/jdsecurity/incidents/database/Database.java
+++ b/src/main/java/ca/jdsecurity/incidents/database/Database.java
@@ -63,17 +63,38 @@ public class Database {
     }
 
     public void createIncidentsTable() {
-        boolean exists = Boolean.TRUE.equals(jdbc.execute((ConnectionCallback<Boolean>) connection -> {
-            try (ResultSet tables = connection.getMetaData().getTables(null, null, "INCIDENTS", new String[]{"TABLE"})) {
+        if (!tableExists()) {
+            log.info("Creating incident table");
+            jdbc.execute(CREATE_TABLE_SQL);
+            return;
+        }
+        // Table already exists (e.g. created by an older version) — bring its schema
+        // up to date so the app self-heals instead of failing on a missing column.
+        log.info("Incident table already exists; checking for schema migrations");
+        ensureColumn("closed_time", "VARCHAR(255)");
+    }
+
+    private boolean tableExists() {
+        return Boolean.TRUE.equals(jdbc.execute((ConnectionCallback<Boolean>) connection -> {
+            // Scope the lookup to the connection's current schema so it stays consistent
+            // with the unqualified DDL/DML the rest of the class issues.
+            try (ResultSet tables = connection.getMetaData().getTables(null, connection.getSchema(), "INCIDENTS", new String[]{"TABLE"})) {
                 return tables.next();
             }
         }));
-        if (exists) {
-            log.info("Incident table already exists");
+    }
+
+    private void ensureColumn(String column, String ddlType) {
+        boolean columnExists = Boolean.TRUE.equals(jdbc.execute((ConnectionCallback<Boolean>) connection -> {
+            try (ResultSet columns = connection.getMetaData().getColumns(null, connection.getSchema(), "INCIDENTS", column.toUpperCase())) {
+                return columns.next();
+            }
+        }));
+        if (columnExists) {
             return;
         }
-        log.info("Creating incident table");
-        jdbc.execute(CREATE_TABLE_SQL);
+        log.info("Adding missing column '{}' to incidents table", column);
+        jdbc.execute("ALTER TABLE incidents ADD COLUMN " + column + " " + ddlType);
     }
 
     public void syncIncidentsTable() throws Exception {


### PR DESCRIPTION
## Summary

Follow-up to #11. The refactor added a `closed_time` column, but `createIncidentsTable()` skips creation when the table already exists and there are no migrations — so deploying the new JAR on top of an existing Derby database 500s on every request (`getRecentIncidents()` reads a column that was never added). This was hit in production; deleting the DB worked around it.

This makes the startup schema check **self-healing**:
- If the table already exists, add any missing columns via `ALTER TABLE` instead of silently skipping.
- Scope the table/column existence checks to the connection's **current schema** (via `Connection.getSchema()`) so they stay consistent with the unqualified DDL/DML the class issues. A `null`-schema metadata lookup can match the table in a *different* schema (e.g. `APP`, used by the pre-refactor `DriverManager` code) while `ALTER TABLE` targets the current one (`SA`, the Spring Boot embedded-DB default user), which fails with `Schema 'SA' does not exist`.

## Testing
Verified by seeding a Derby database with the **old 7-column schema** (in the `SA` schema, matching the app's connection) plus a sample row, then starting the new JAR against it:
- Log shows `checking for schema migrations` → `Adding missing column 'closed_time'` → `sync completed (57 incidents)`.
- `GET /` returns **200** (previously 500).
- `./mvnw test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)